### PR TITLE
Replace mimemagic with mini_mime

### DIFF
--- a/lib/tracker_api.rb
+++ b/lib/tracker_api.rb
@@ -4,7 +4,7 @@ require 'tracker_api/version'
 require 'faraday'
 require 'faraday_middleware'
 require 'pathname'
-require 'mimemagic'
+require 'mini_mime'
 
 if defined?(ActiveSupport)
   require 'active_support/core_ext/object/blank'

--- a/lib/tracker_api/file_utility.rb
+++ b/lib/tracker_api/file_utility.rb
@@ -2,7 +2,7 @@ module TrackerApi
   class FileUtility
     class << self
       def get_file_upload(file)
-        mime_type = MimeMagic.by_path(file)
+        mime_type = MiniMime.lookup_by_filename(file)
         { :file => Faraday::UploadIO.new(file, mime_type) }
       end
 

--- a/tracker_api.gemspec
+++ b/tracker_api.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'equalizer'
   spec.add_dependency 'representable'
   spec.add_dependency 'multi_json'
-  spec.add_dependency 'mimemagic'
+  spec.add_dependency 'mini_mime'
 end


### PR DESCRIPTION
To address: https://github.com/ProductPlan/tracker_api/issues/144 and https://github.com/ProductPlan/tracker_api/issues/143

Switch to `mini_mime` similar to what Rails did: https://github.com/rails/rails/commit/7c55e373be1d40a72581cb6d4131eb2d9e0c2fcb

Not really a necessary change now that `mimemagic` has released new versions with MIT licenses 🤷 .