### PR TITLE
build: drop ruby 2.5 from CI and add 3.0 and 3.1

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.7, 2.6, 2.5]
+        ruby-version: [3.1, 3.0, 2.7, 2.6]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,4 +31,4 @@ jobs:
         CC_TEST_REPORTER_ID: 2a6849be8214739deef0090b810b945ce9a550a4d8279d242cb03242d1ad53c5
       with:
         coverageLocations: ${{github.workspace}}/coverage/.resultset.json:simplecov
-      if: matrix.ruby-version == '2.7'
+      if: matrix.ruby-version == '3.1'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This gem allows you to easily use the [Pivotal Tracker v5 API](https://www.pivot
 
 It’s powered by [Faraday](https://github.com/lostisland/faraday) and [Virtus](https://github.com/solnic/virtus).
 
+## Compatibility
+
+This gem is tested against the following officially supported Ruby versions:
+ - Minimum Ruby Version: 2.6.x
+ - Latest Ruby Supported: 3.1.x
+
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
- Ruby 2.5 was EOL several months ago, so will remove official support for it
- Officially support Ruby 3.0 and 3.1