### PR TITLE
faraday 2 support

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -9,12 +9,17 @@ on:
 jobs:
   test:
 
+    name: Specs - Ruby ${{ matrix.ruby-version }} ${{matrix.gemfile}}
     runs-on: ubuntu-latest
     env:
       CC_TEST_REPORTER_ID: 2a6849be8214739deef0090b810b945ce9a550a4d8279d242cb03242d1ad53c5
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
 
     strategy:
       matrix:
+        gemfile:
+          - faraday-1
+          - faraday-2
         ruby-version:
           - "3.1"
           - "3.0"
@@ -35,4 +40,4 @@ jobs:
       run: bundle exec rake test
     - name: Upload Coverage
       uses: paambaati/codeclimate-action@v3.0.0
-      if: matrix.ruby-version == '3.1'
+      if: matrix.ruby-version == '3.1' && matrix.gemfile == 'faraday-2'

--- a/gemfiles/faraday-1.gemfile
+++ b/gemfiles/faraday-1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'faraday', '~> 1.10'
+
+gemspec path: '../'

--- a/gemfiles/faraday-2.gemfile
+++ b/gemfiles/faraday-2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'faraday', '~> 2.2'
+
+gemspec path: '../'

--- a/lib/tracker_api.rb
+++ b/lib/tracker_api.rb
@@ -2,7 +2,7 @@ require 'tracker_api/version'
 
 # dependencies
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/multipart'
 require 'pathname'
 require 'mini_mime'
 

--- a/lib/tracker_api/client.rb
+++ b/lib/tracker_api/client.rb
@@ -25,7 +25,7 @@ module TrackerApi
       @url               = Addressable::URI.parse(url).to_s
       @api_version       = options.fetch(:api_version, '/services/v5')
       @logger            = options.fetch(:logger, ::Logger.new(nil))
-      adapter            = options.fetch(:adapter) { defined?(JRUBY_VERSION) ? :net_http : :excon }
+      adapter            = options.fetch(:adapter, :net_http)
       connection_options = options.fetch(:connection_options, { ssl: { verify: true } })
       @auto_paginate     = options.fetch(:auto_paginate, true)
       @token             = options[:token]

--- a/lib/tracker_api/logger.rb
+++ b/lib/tracker_api/logger.rb
@@ -1,5 +1,5 @@
 module TrackerApi
-  class Logger < Faraday::Response::Middleware
+  class Logger < Faraday::Middleware
     extend Forwardable
 
     def initialize(app, logger = nil)

--- a/tracker_api.gemspec
+++ b/tracker_api.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable'
   spec.add_dependency 'virtus'
-  spec.add_dependency 'faraday'
-  spec.add_dependency 'faraday_middleware'
+  spec.add_dependency 'faraday', ['>= 1.10', '< 3.0']
+  spec.add_dependency 'faraday-multipart'
   spec.add_dependency 'equalizer'
   spec.add_dependency 'representable'
   spec.add_dependency 'multi_json'

--- a/tracker_api.gemspec
+++ b/tracker_api.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus'
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday_middleware'
-  spec.add_dependency 'excon'
   spec.add_dependency 'equalizer'
   spec.add_dependency 'representable'
   spec.add_dependency 'multi_json'


### PR DESCRIPTION
This brings in faraday 2.0 support by:

- Dropping `faraday_middleware`. Common middleware now bundled with newer versions of Faraday.
- Simplifying our dependencies by dropping `excon`. Users can still choose to use that adapter with options, but we will default to `net_http`.
- Requiring Faraday >= 1.10. Faraday 1.10 is the lowest version on the 1.x branch that has most of the middleware we need bundled in.
- Updating our build matrix to test against multiple versions of Faraday.