### PR TITLE
Add projected completion date for epics

### DIFF
--- a/lib/tracker_api/resources/epic.rb
+++ b/lib/tracker_api/resources/epic.rb
@@ -18,6 +18,7 @@ module TrackerApi
       attribute :project_id, Integer
       attribute :updated_at, DateTime
       attribute :completed_at, DateTime
+      attribute :projected_completion, DateTime
       attribute :url, String
 
       class UpdateRepresenter < Representable::Decorator


### PR DESCRIPTION
Exposes the `projected_completion` attribute from the Pivotal API on the epic resource

### Usage
```ruby
client = TrackerApi::Client.new(token: token)
project = client.project(project_id)
epics = project.epics(fields: ":default,followers,projected_completion")
projected_completion = epics.first.projected_completion
```

### Documentation
https://www.pivotaltracker.com/help/api/rest/v5#epic_resource