### PR TITLE
Add status attribute for project

### DIFF
--- a/lib/tracker_api/resources/project.rb
+++ b/lib/tracker_api/resources/project.rb
@@ -33,6 +33,7 @@ module TrackerApi
       attribute :public, Boolean
       attribute :start_date, DateTime
       attribute :start_time, DateTime
+      attribute :status, String
       attribute :time_zone, TimeZone
       attribute :updated_at, DateTime
       attribute :velocity_averaged_over, Integer


### PR DESCRIPTION
Exposes the `status` attribute from the Pivotal API on the project resource.

### Usage

```ruby

client = TrackerApi::Client.new(token: token)
project = client.project(project_id, fields: ':default,status')
puts(project.status)
```
### Documentation
https://www.pivotaltracker.com/help/api/rest/v5#project_resource